### PR TITLE
Add support for Neovim

### DIFF
--- a/plugin/traces.vim
+++ b/plugin/traces.vim
@@ -1,4 +1,4 @@
-if !(v:version > 800 || v:version == 800 && has("patch1067")) || exists("g:loaded_traces_plugin") || &cp
+if !(v:version > 800 || v:version == 800 && has("patch1067") || has('nvim')) || exists("g:loaded_traces_plugin") || &cp
   finish
 endif
 let g:loaded_traces_plugin = 1


### PR DESCRIPTION
It works fine for me. Not sure what feature `patch1067` of Vim 8 had, though, so it may need to check the version of Neovim as well.