### PR TITLE
TracesSearch highlight group

### DIFF
--- a/autoload/traces.vim
+++ b/autoload/traces.vim
@@ -566,7 +566,7 @@ function! s:highlight(group, pattern, priority) abort
     return
   endif
 
-  if &hlsearch && !empty(a:pattern) && a:group ==# 'Search'
+  if &hlsearch && !empty(a:pattern) && a:group ==# 'TracesSearch'
     let &hlsearch = 0
   endif
   if &scrolloff !=# 0
@@ -674,14 +674,14 @@ function! s:live_substitute(cmdl) abort
   call s:pos_pattern(ptrn, range, dlm, 1)
 
   if !g:traces_substitute_preview || &readonly || !&modifiable || empty(str) && empty(l_dlm)
-    call s:highlight('Search', ptrn, 101)
+    call s:highlight('TracesSearch', ptrn, 101)
     return
   endif
 
   call s:save_undo_history()
 
   if s:buf[s:nr].undo_file is 0
-    call s:highlight('Search', ptrn, 101)
+    call s:highlight('TracesSearch', ptrn, 101)
     return
   endif
 
@@ -712,13 +712,13 @@ function! s:live_substitute(cmdl) abort
     let range[-1] -= lines
     call s:highlight('Visual', s:get_selection_regexp(range), 100)
   endif
-  call s:highlight('Search', s:s_start . '\_.\{-}' . s:s_end, 101)
+  call s:highlight('TracesSearch', s:s_start . '\_.\{-}' . s:s_end, 101)
   call s:highlight('Conceal', s:s_start . '\|' . s:s_end, 102)
 endfunction
 
 function! s:live_global(cmdl) abort
   if empty(a:cmdl.range.specifier) && has_key(a:cmdl.cmd.args, 'pattern')
-    call s:highlight('Search', a:cmdl.cmd.args.pattern, 101)
+    call s:highlight('TracesSearch', a:cmdl.cmd.args.pattern, 101)
     call s:pos_pattern(a:cmdl.cmd.args.pattern, a:cmdl.range.abs, a:cmdl.cmd.args.delimiter, 0)
   endif
 endfunction
@@ -978,7 +978,7 @@ function! traces#init(cmdl) abort
     if (!empty(cmdl.cmd.name) || s:buf[s:nr].show_range) && !get(s:, 'entire_file')
       call s:highlight('Visual', cmdl.range.pattern, 100)
       if empty(cmdl.cmd.name)
-        call s:highlight('Search', cmdl.range.specifier, 101)
+        call s:highlight('TracesSearch', cmdl.range.specifier, 101)
       endif
       call s:pos_range(cmdl.range.end, cmdl.range.specifier)
     endif
@@ -996,7 +996,7 @@ function! traces#init(cmdl) abort
       call s:highlight('Visual', '', 100)
     endif
     if empty(cmdl.cmd.name) && empty(cmdl.range.specifier)
-      call s:highlight('Search', '', 101)
+      call s:highlight('TracesSearch', '', 101)
     endif
   endif
 

--- a/doc/traces.txt
+++ b/doc/traces.txt
@@ -9,6 +9,7 @@ Settings                |traces-settings|
                           - |g:traces_preserve_view_state|
                           - |g:traces_substitute_preview|
                           - |g:traces_skip_modifiers|
+Highlights              |traces-highlights|
 Bugs                    |traces-bugs|
 Changelog               |traces-changelog|
 
@@ -76,6 +77,12 @@ If value is 1, do-modifiers, |cdo|, |cfdo|, |ldo|, |lfdo|, |bufdo|, |tabdo|,
 |argdo| and |windo,| will be ignored when processing command line.
 
   Default value: 1
+
+==============================================================================
+HIGHLIGHTS					*traces-highlights*
+
+                                                *hl-TracesSearch*
+Search pattern highlighting. Links to |hl-Search| by default.
 
 ==============================================================================
 BUGS						*traces-bugs*

--- a/plugin/traces.vim
+++ b/plugin/traces.vim
@@ -82,5 +82,7 @@ augroup traces_augroup
   autocmd CmdlineLeave : call traces#cmdl_leave()
 augroup END
 
+highlight default link TracesSearch Search
+
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/test/traces.vader
+++ b/test/traces.vader
@@ -262,7 +262,7 @@ Execute (Range):
 Execute (Range):
   6
   call traces#init('/ten/;?four')
-  AssertEqual '\m\%>3l\%<5l\%(\mfour\m\)', Group('Search')
+  AssertEqual '\m\%>3l\%<5l\%(\mfour\m\)', Group('TracesSearch')
 
 Execute (Range):
   6
@@ -329,16 +329,16 @@ Execute (Range):
 Execute (Range):
   call traces#init('7,/four/s/foobar')
   AssertEqual '\%>3l\%<8l\_.', Group('Visual')
-  AssertEqual '\m\%>3l\%<8l\%(\mfoobar\m\)', Group('Search')
+  AssertEqual '\m\%>3l\%<8l\%(\mfoobar\m\)', Group('TracesSearch')
 
 Execute (Global):
   call traces#init('7,/four/g/foobar')
   AssertEqual '\%>3l\%<8l\_.', Group('Visual')
-  AssertEqual '\m\%>3l\%<8l\%(\mfoobar\m\)', Group('Search')
+  AssertEqual '\m\%>3l\%<8l\%(\mfoobar\m\)', Group('TracesSearch')
 
 Execute (Global):
   call traces#init('g/foobar')
-  AssertEqual '\mfoobar', Group('Search')
+  AssertEqual '\mfoobar', Group('TracesSearch')
 
 Execute (Range):
   call traces#init('7;/four/')


### PR DESCRIPTION
Create a `TracesSearch` highlight group for the current search pattern, linked to `Search` by default.

For colorschemes where 'Search' highlighting is subtle, it's nice to use something more distinct for things like global substitution.This is especially true if 'Search' has a similar appearance to 'Visual', because matches will be hard to see when a range is in effect.

To illustrate, I use a subtle Search highlight to make IncSearch stand out:
![incsearch](https://user-images.githubusercontent.com/1672874/39100439-9e4086a8-4658-11e8-9ca5-66519e19a0a6.png)

#### Before
When live-previewing a substitution, the Search group doesn't stand out as much as I'd like.

global:
![master-subst](https://user-images.githubusercontent.com/1672874/39100445-bb90d9ce-4658-11e8-831a-b88e3f200c38.png)

range:
![master-range](https://user-images.githubusercontent.com/1672874/39100472-033c75da-4659-11e8-9140-4f63cbb56209.png)


#### After
Now I can customize TracesSearch to stand out more.

global:
![feature-subst](https://user-images.githubusercontent.com/1672874/39100483-59d935b8-4659-11e8-9c95-ec37018adaae.png)

range:
![feature-range](https://user-images.githubusercontent.com/1672874/39100486-605dad38-4659-11e8-84f1-7b1ec2dab575.png)

___
The new group links to `Search` by default. Users interested in changing the highlight without delving into colorschemes can link it to another group in their vimrc. For example:
``` vim
highlight! link TracesSearch IncSearch
```