### PR TITLE
Make autocmds nested

### DIFF
--- a/plugin/traces.vim
+++ b/plugin/traces.vim
@@ -77,9 +77,9 @@ silent! cnoremap <unique> <expr> <c-r><c-o><c-p> traces#check_b() ? "\<c-r>\<c-r
 
 augroup traces_augroup
   autocmd!
-  autocmd CmdlineEnter,CmdwinLeave : call s:t_start()
-  autocmd CmdlineLeave,CmdwinEnter : call s:t_stop()
-  autocmd CmdlineLeave : call traces#cmdl_leave()
+  autocmd CmdlineEnter,CmdwinLeave : nested call s:t_start()
+  autocmd CmdlineLeave,CmdwinEnter : nested call s:t_stop()
+  autocmd CmdlineLeave : nested call traces#cmdl_leave()
 augroup END
 
 highlight default link TracesSearch Search


### PR DESCRIPTION
Some plugins, e.g. [vim-cool](https://github.com/romainl/vim-cool), use the `OptionSet` autocmd to detect when `hlsearch` is set, but because traces sets it in an autocmd that is not nested (`:help autocmd-nested`), vim-cool can not detect that it is set, gives an error and ceases to work for the remainder of the session.