### PR TITLE
Add setting (g:traces_enabled) to enable/disable the plugin

### DIFF
--- a/doc/traces.txt
+++ b/doc/traces.txt
@@ -59,6 +59,11 @@ Neovim v0.2.3+
 ==============================================================================
 SETTINGS					*traces-settings*
 
+                                                *g:traces_enabled*
+If value is 0, this plugin will be disabled and no highlighting will be done.
+
+  Default value: 1
+
                                                 *g:traces_preserve_view_state*
 If value is 1, view position  will not be changed when highlighting ranges or
 patterns outside initial view position.

--- a/plugin/traces.vim
+++ b/plugin/traces.vim
@@ -6,6 +6,7 @@ let g:loaded_traces_plugin = 1
 let s:cpo_save = &cpo
 set cpo-=C
 
+let g:traces_enabled = get(g:, 'traces_enabled', 1)
 let g:traces_preserve_view_state = get(g:, 'traces_preserve_view_state')
 let g:traces_substitute_preview  = get(g:, 'traces_substitute_preview', 1)
 let g:traces_skip_modifiers      = get(g:, 'traces_skip_modifiers', 1)
@@ -36,6 +37,9 @@ function! s:create_cmdl_changed_au(...) abort
 endfunction
 
 function! s:t_start() abort
+  if !g:traces_enabled
+    return
+  endif
   if exists('##CmdlineChanged')
     let s:track_cmdl_timer = timer_start(30,function('s:create_cmdl_changed_au'))
   else


### PR DESCRIPTION
Create a new setting that will allow user to temporarily disable the
plugin, similar to how in native Vim one can set 'hlsearch' on/off at
will.