### PR TITLE
fix(cmdline): do not restore cmdline when it has different windows

### DIFF
--- a/autoload/traces.vim
+++ b/autoload/traces.vim
@@ -762,6 +762,7 @@ function! s:cmdl_enter(view) abort
   let s:buf[s:nr].redraw = 1
   let s:buf[s:nr].s_mark = (&encoding == 'utf-8' ? "\uf8b4" : '' )
   let s:buf[s:nr].winrestcmd = winrestcmd()
+  let s:buf[s:nr].win_count = winnr('$')
   let s:buf[s:nr].cur_win = win_getid()
   let s:buf[s:nr].alt_win = win_getid(winnr('#'))
   let s:buf[s:nr].winwidth = &winwidth
@@ -815,7 +816,9 @@ function! traces#cmdl_leave() abort
   endif
 
   if winrestcmd() isnot s:buf[s:nr].winrestcmd
-    noautocmd execute s:buf[s:nr].winrestcmd
+    if winnr('$') ==# s:buf[s:nr].win_count
+      noautocmd execute s:buf[s:nr].winrestcmd
+    endif
   endif
   if winsaveview() !=# s:buf[s:nr].view
     call winrestview(s:buf[s:nr].view)


### PR DESCRIPTION
When there is float window open and enter cmdline, then float window close. finally leave the cmdline it will cause cmdline become too big.