### PR TITLE
Restore &incsearch safely

### DIFF
--- a/plugin/traces.vim
+++ b/plugin/traces.vim
@@ -97,7 +97,7 @@ augroup traces_augroup
   " https://github.com/neovim/neovim/pull/12721/commits/e8a8b9ed08405c830a049c4e43910c5ce9cdb669
   autocmd CmdlineEnter,CmdwinLeave : let s:incsearch = &incsearch
         \| noautocmd let &incsearch = 0
-  autocmd CmdlineLeave,CmdwinEnter : noautocmd let &incsearch = s:incsearch
+  autocmd CmdlineLeave,CmdwinEnter : if exists('s:incsearch') | noautocmd let &incsearch = s:incsearch | endif
 augroup END
 
 highlight default link TracesSearch Search


### PR DESCRIPTION
This plugin is lazily loaded in my vimrc and the following error mostly happens if I open vim and quickly call some ex command. This patch resolves my problem and is just safer :(.

![Screenshot from 2021-01-11 21-33-33](https://user-images.githubusercontent.com/8850248/104189352-837ea300-5455-11eb-84a2-17103a969cc0.png)
